### PR TITLE
Optimize the style of the head of the docs,blog,community,download,de…

### DIFF
--- a/development/en-us/development-environment-setup.md
+++ b/development/en-us/development-environment-setup.md
@@ -1,3 +1,5 @@
+## Development Environment Setup
+
 #### Preparation
 
 1. First, fork the [dolphinscheduler](https://github.com/apache/dolphinscheduler) code from the remote repository to your local repository.

--- a/development/zh-cn/development-environment-setup.md
+++ b/development/zh-cn/development-environment-setup.md
@@ -1,3 +1,5 @@
+## 环境搭建
+
 #### 准备工作
 
 1. 首先从远端仓库 fork [dolphinscheduler](https://github.com/apache/dolphinscheduler) 一份代码到自己的仓库中

--- a/src/components/md2html/index.scss
+++ b/src/components/md2html/index.scss
@@ -7,14 +7,14 @@
     max-width: $contentWidth;
     margin: 0 auto;
     box-sizing: border-box;
-    padding: 40px 40px 60px;
+    padding: 50px 0px 60px;
     position: relative;
     min-height: 1100px;
     .doc-content {
       display: inline-block;
       vertical-align: top;
       box-sizing: border-box;
-      padding: 20px 6% 0;
+      padding: 40px 6% 0;
       width: calc(100% - #{$sideMenuWidth});
     }
   }

--- a/src/components/sidemenu/index.scss
+++ b/src/components/sidemenu/index.scss
@@ -4,7 +4,7 @@
   width: $sideMenuWidth;
   position: relative;
   display: inline-block;
-  padding: 20px 0;
+  padding: 60px 0;
   .sidemenu-toggle {
     text-align: center;
     cursor: pointer;

--- a/src/markdown.scss
+++ b/src/markdown.scss
@@ -379,7 +379,7 @@
 }
 
 .markdown-body>*:first-child {
-  margin-top: 0 !important;
+  margin-top: 20px;
 }
 
 .markdown-body>*:last-child {

--- a/src/pages/blog/index.jsx
+++ b/src/pages/blog/index.jsx
@@ -18,13 +18,13 @@ class Blog extends Language {
     return (
       <div className="blog-list-page">
         <Header
-          type="normal"
+          type="dark"
           currentKey="blog"
-          logo="/img/hlogo_colorful.svg"
+          logo="/img/hlogo_white.svg"
           language={language}
           onLanguageChange={this.onLanguageChange}
         />
-        <Bar img="/img/system/blog.png" text={dataSource.barText} />
+        
         <section className="blog-container">
           <div className="col col-18 left-part">
             <PageSlider pageSize={5}>

--- a/src/pages/blog/index.md.jsx
+++ b/src/pages/blog/index.md.jsx
@@ -14,8 +14,8 @@ class BlogDetail extends Md2Html(Language) {
       <div className="blog-detail-page">
         <Header
           currentKey="blog"
-          type="normal"
-          logo="/img/hlogo_colorful.svg"
+          type="dark"
+          logo="/img/hlogo_white.svg"
           language={language}
           onLanguageChange={this.onLanguageChange}
         />

--- a/src/pages/blog/index.scss
+++ b/src/pages/blog/index.scss
@@ -6,7 +6,7 @@
     max-width: $contentWidth;
     margin: 0 auto;
     box-sizing: border-box;
-    padding: 50px 8% 80px;
+    padding: 120px 8% 80px;
     .col {
       display: inline-block;
       box-sizing: border-box;

--- a/src/pages/community/index.jsx
+++ b/src/pages/community/index.jsx
@@ -20,12 +20,12 @@ class Community extends Language {
       <div className="community-page">
         <Header
           currentKey="community"
-          type="normal"
-          logo="/img/hlogo_colorful.svg"
+          type="dark"
+          logo="/img/hlogo_white.svg"
           language={language}
           onLanguageChange={this.onLanguageChange}
         />
-        <Bar img="/img/system/community.png" text={dataSource.barText} />
+       
         <section className="content-section">
           <Sidemenu dataSource={dataSource.sidemenu} />
           <div className="doc-content markdown-body">

--- a/src/pages/community/index.md.jsx
+++ b/src/pages/community/index.md.jsx
@@ -17,12 +17,12 @@ class Community extends Md2Html(Language) {
       <div className="md2html community-page">
         <Header
           currentKey="community"
-          type="normal"
-          logo="/img/hlogo_colorful.svg"
+          type="dark"
+          logo="/img/hlogo_white.svg"
           language={language}
           onLanguageChange={this.onLanguageChange}
         />
-        <Bar img="/img/system/community.png" text={dataSource.barText} />
+      
         <section className="content-section">
           <Sidemenu dataSource={dataSource.sidemenu} />
           <div

--- a/src/pages/community/index.scss
+++ b/src/pages/community/index.scss
@@ -6,20 +6,20 @@
     max-width: $contentWidth;
     margin: 0 auto;
     box-sizing: border-box;
-    padding: 40px 40px 60px;
+    padding: 62px 0px 60px;
     position: relative;
     min-height: 1100px;
     .doc-content {
       display: inline-block;
       vertical-align: top;
       box-sizing: border-box;
-      padding: 20px 6% 0;
+      padding: 40px 6% 0;
       width: calc(100% - #{$sideMenuWidth});
     }
   }
   @media screen and (max-width: $mobileWidth) {
     .content-section {
-      padding-left: 20px;
+      padding-left: 0px;
       padding-right: 20px;
       .doc-content {
         width: 100%;
@@ -29,7 +29,7 @@
       position: absolute;
       z-index: 100;
       left: 0;
-      top: 40px;
+      top: 20px;
       min-height: 510px;
     }
   }

--- a/src/pages/development/index.md.jsx
+++ b/src/pages/development/index.md.jsx
@@ -4,7 +4,6 @@ import Language from '../../components/language';
 import Header from '../../components/header';
 import Footer from '../../components/footer';
 import Md2Html from '../../components/md2html';
-import Bar from '../../components/bar';
 import Sidemenu from '../../components/sidemenu';
 import developmentConfig from '../../../site_config/development';
 
@@ -17,12 +16,12 @@ class Development extends Md2Html(Language) {
       <div className="md2html development-page">
         <Header
           currentKey="development"
-          type="normal"
-          logo="/img/hlogo_colorful.svg"
+          type="dark"
+          logo="/img/hlogo_white.svg"
           language={language}
           onLanguageChange={this.onLanguageChange}
         />
-        <Bar img="/img/system/development.png" text={dataSource.barText} />
+
         <section className="content-section">
           <Sidemenu dataSource={dataSource.sidemenu} />
           <div

--- a/src/pages/docs/index.md.jsx
+++ b/src/pages/docs/index.md.jsx
@@ -5,7 +5,6 @@ import Language from '../../components/language';
 import Header from '../../components/header';
 import Footer from '../../components/footer';
 import Md2Html from '../../components/md2html';
-import Bar from '../../components/bar';
 import Sidemenu from '../../components/sidemenu';
 import siteConfig from '../../../site_config/site';
 import docs120Config from '../../../site_config/docs1-2-0';
@@ -55,12 +54,11 @@ class Docs extends Md2Html(Language) {
       <div className="md2html docs-page">
         <Header
           currentKey="docs"
-          type="normal"
-          logo="/img/hlogo_colorful.svg"
+          type="dark"
+          logo="/img/hlogo_white.svg"
           language={language}
           onLanguageChange={this.onLanguageChange}
         />
-        <Bar img="/img/system/docs.png" text={dataSource.barText} />
         <section className="content-section">
           <Sidemenu dataSource={dataSource.sidemenu} />
           <div
@@ -68,6 +66,7 @@ class Docs extends Md2Html(Language) {
             ref={(node) => { this.markdownContainer = node; }}
             dangerouslySetInnerHTML={{ __html }}
           />
+         
         </section>
         <Footer logo="/img/ds_gray.svg" language={language} />
       </div>

--- a/src/pages/download/index.md.jsx
+++ b/src/pages/download/index.md.jsx
@@ -4,7 +4,6 @@ import Language from '../../components/language';
 import Header from '../../components/header';
 import Footer from '../../components/footer';
 import Md2Html from '../../components/md2html';
-import Bar from '../../components/bar';
 import Sidemenu from '../../components/sidemenu';
 import downloadConfig from '../../../site_config/download';
 
@@ -17,12 +16,12 @@ class Download extends Md2Html(Language) {
       <div className="md2html download-page">
         <Header
           currentKey="download"
-          type="normal"
-          logo="/img/hlogo_colorful.svg"
+          type="dark"
+          logo="/img/hlogo_white.svg"
           language={language}
           onLanguageChange={this.onLanguageChange}
         />
-        <Bar img="/img/system/download.png" text={dataSource.barText} />
+
         <section className="content-section">
           <Sidemenu dataSource={dataSource.sidemenu} />
           <div


### PR DESCRIPTION
1、Optimize the style of the head of the docs,blog,community,download,development page.the background color of the head turns to black.
2、Optimize the style of  the development-environment-setup.md.Add <h1>Development Environment Setup</h1>,both of zh and es.
3、remove bar in all of these pages.
<img width="1261" alt="blog" src="https://user-images.githubusercontent.com/19991611/115808409-0633d880-a41d-11eb-83fa-1a0b3b629279.png">
<img width="1262" alt="community" src="https://user-images.githubusercontent.com/19991611/115808418-09c75f80-a41d-11eb-8162-5b289f3d79b0.png">
<img width="1262" alt="development" src="https://user-images.githubusercontent.com/19991611/115808422-0b912300-a41d-11eb-98b2-30784dc6cbee.png">
<img width="1265" alt="doc" src="https://user-images.githubusercontent.com/19991611/115808424-0cc25000-a41d-11eb-9184-5746e1bc01ba.png">
<img width="1264" alt="download" src="https://user-images.githubusercontent.com/19991611/115808425-0d5ae680-a41d-11eb-8c9c-d3c50510d4a9.png">
