### PR TITLE
Remove contributor-guide section

### DIFF
--- a/site_config/community.jsx
+++ b/site_config/community.jsx
@@ -58,10 +58,6 @@ export default {
             title: 'Code of Conduct',
             link: '/en-us/community/development/code-conduct.html',
           },
-          {
-            title: 'Contributor Guide',
-            link: '/en-us/community/contributor-guide.html',
-          },
         ],
       },
       {
@@ -258,10 +254,6 @@ export default {
           {
             title: '行为准则',
             link: '/zh-cn/community/development/code-conduct.html',
-          },
-          {
-            title: '贡献者指南',
-            link: '/zh-cn/community/contributor-guide.html',
           },
         ],
       },


### PR DESCRIPTION
Correct our docs, it seem that we do not need section `contributor-guide` anymore
and closes: https://github.com/apache/dolphinscheduler/issues/6107