### PR TITLE
[fix] correct the wrong explanation for `add a new article for docs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ description: some description
 1. Add new .md file under docs/en-us or docs/zh-cn.
 2. Update site_config/docs.js, add a new entry in either en-us or zh-cn.
 3. Run docsite start locally to verify the article can be displayed correctly.
-4. Send the pull request contains the *.md and development.js only.
+4. Send the pull request contains the *.md and docs.js only.
 
 Best Regards.  
 				Thanks for reading :)


### PR DESCRIPTION
correct the wrong explanation for `add a new article for docs`