### PR TITLE
Fix broken download link

### DIFF
--- a/docs/en-us/2.0.0/user_doc/guide/installation/pseudo-cluster.md
+++ b/docs/en-us/2.0.0/user_doc/guide/installation/pseudo-cluster.md
@@ -9,7 +9,7 @@ If you are a green hand and want to experience DolphinScheduler, we recommended 
 Pseudo-cluster deployment of DolphinScheduler requires external software support
 
 * JDK：Download [JDK][jdk] (1.8+), and configure `JAVA_HOME` to and `PATH` variable. You can skip this step, if it already exists in your environment.
-* Binary package: Download the DolphinScheduler binary package at [download page](../../../../../../download/en-us/download.md)
+* Binary package: Download the DolphinScheduler binary package at [download page](../../../../../../en-us/download/download.md)
 * Database: PostgreSQL (8.2.15+) or MySQL (5.7+), you can choose one of the two, such as MySQL requires JDBC Driver 5.1.47+
 * Registry Center: ZooKeeper (3.4.6+)，[download link][zookeeper]
 * Process tree analysis

--- a/docs/en-us/2.0.0/user_doc/guide/installation/standalone.md
+++ b/docs/en-us/2.0.0/user_doc/guide/installation/standalone.md
@@ -9,7 +9,7 @@ If you are a green hand and want to experience DolphinScheduler, we recommended 
 ## Prepare
 
 * JDK：Download [JDK][jdk] (1.8+), and configure `JAVA_HOME` to and `PATH` variable. You can skip this step, if it already exists in your environment.
-* Binary package: Download the DolphinScheduler binary package at [download page](../../../../../../download/en-us/download.md)
+* Binary package: Download the DolphinScheduler binary package at [download page](../../../../../../en-us/download/download.md)
 
 ## Start DolphinScheduler Standalone Server
 

--- a/docs/en-us/dev/user_doc/guide/installation/pseudo-cluster.md
+++ b/docs/en-us/dev/user_doc/guide/installation/pseudo-cluster.md
@@ -9,7 +9,7 @@ If you are a green hand and want to experience DolphinScheduler, we recommended 
 Pseudo-cluster deployment of DolphinScheduler requires external software support
 
 * JDK：Download [JDK][jdk] (1.8+), and configure `JAVA_HOME` to and `PATH` variable. You can skip this step, if it already exists in your environment.
-* Binary package: Download the DolphinScheduler binary package at [download page](../../../../../../download/en-us/download.md)
+* Binary package: Download the DolphinScheduler binary package at [download page](../../../../../../en-us/download/download.md)
 * Database: PostgreSQL (8.2.15+) or MySQL (5.7+), you can choose one of the two, such as MySQL requires JDBC Driver 5.1.47+
 * Registry Center: ZooKeeper (3.4.6+)，[download link][zookeeper]
 * Process tree analysis

--- a/docs/en-us/dev/user_doc/guide/installation/standalone.md
+++ b/docs/en-us/dev/user_doc/guide/installation/standalone.md
@@ -9,7 +9,7 @@ If you are a green hand and want to experience DolphinScheduler, we recommended 
 ## Prepare
 
 * JDK：Download [JDK][jdk] (1.8+), and configure `JAVA_HOME` to and `PATH` variable. You can skip this step, if it already exists in your environment.
-* Binary package: Download the DolphinScheduler binary package at [download page](../../../../../../download/en-us/download.md)
+* Binary package: Download the DolphinScheduler binary package at [download page](../../../../../../en-us/download/download.md)
 
 ## Start DolphinScheduler Standalone Server
 

--- a/docs/zh-cn/2.0.0/user_doc/guide/installation/pseudo-cluster.md
+++ b/docs/zh-cn/2.0.0/user_doc/guide/installation/pseudo-cluster.md
@@ -9,7 +9,7 @@
 伪分布式部署 DolphinScheduler 需要有外部软件的支持
 
 * JDK：下载[JDK][jdk] (1.8+)，并将 JAVA_HOME 配置到以及 PATH 变量中。如果你的环境中已存在，可以跳过这步。
-* 二进制包：在[下载页面](../../../../../../download/zh-cn/download.md)下载 DolphinScheduler 二进制包
+* 二进制包：在[下载页面](../../../../../../zh-cn/download/download.md)下载 DolphinScheduler 二进制包
 * 数据库：PostgreSQL (8.2.15+) 或者 MySQL (5.7+)，两者任选其一即可，如 MySQL 则需要 JDBC Driver 5.1.47+
 * 注册中心：ZooKeeper (3.4.6+)，[下载地址][zookeeper]
 * 进程树分析

--- a/docs/zh-cn/2.0.0/user_doc/guide/installation/standalone.md
+++ b/docs/zh-cn/2.0.0/user_doc/guide/installation/standalone.md
@@ -9,7 +9,7 @@ Standalone 仅适用于 DolphinScheduler 的快速体验.
 ## 前置准备工作
 
 * JDK：下载[JDK][jdk] (1.8+)，并将 `JAVA_HOME` 配置到以及 `PATH` 变量中。如果你的环境中已存在，可以跳过这步。
-* 二进制包：在[下载页面](../../../../../../download/zh-cn/download.md)下载 DolphinScheduler 二进制包
+* 二进制包：在[下载页面](../../../../../../zh-cn/download/download.md)下载 DolphinScheduler 二进制包
 
 ## 启动 DolphinScheduler Standalone Server
 

--- a/docs/zh-cn/dev/user_doc/guide/installation/pseudo-cluster.md
+++ b/docs/zh-cn/dev/user_doc/guide/installation/pseudo-cluster.md
@@ -9,7 +9,7 @@
 伪分布式部署 DolphinScheduler 需要有外部软件的支持
 
 * JDK：下载[JDK][jdk] (1.8+)，并将 JAVA_HOME 配置到以及 PATH 变量中。如果你的环境中已存在，可以跳过这步。
-* 二进制包：在[下载页面](../../../../../../download/zh-cn/download.md)下载 DolphinScheduler 二进制包
+* 二进制包：在[下载页面](../../../../../../zh-cn/download/download.md)下载 DolphinScheduler 二进制包
 * 数据库：PostgreSQL (8.2.15+) 或者 MySQL (5.7+)，两者任选其一即可，如 MySQL 则需要 JDBC Driver 5.1.47+
 * 注册中心：ZooKeeper (3.4.6+)，[下载地址][zookeeper]
 * 进程树分析

--- a/docs/zh-cn/dev/user_doc/guide/installation/standalone.md
+++ b/docs/zh-cn/dev/user_doc/guide/installation/standalone.md
@@ -9,7 +9,7 @@ Standalone 仅适用于 DolphinScheduler 的快速体验.
 ## 前置准备工作
 
 * JDK：下载[JDK][jdk] (1.8+)，并将 `JAVA_HOME` 配置到以及 `PATH` 变量中。如果你的环境中已存在，可以跳过这步。
-* 二进制包：在[下载页面](../../../../../../download/zh-cn/download.md)下载 DolphinScheduler 二进制包
+* 二进制包：在[下载页面](../../../../../../zh-cn/download/download.md)下载 DolphinScheduler 二进制包
 
 ## 启动 DolphinScheduler Standalone Server
 


### PR DESCRIPTION
@lukairui find out some of our download link is broken, but have no time, so I submit this patch to fix it.

This issue due to we do not use markdown file relative location to generation url link. The download page relative location  is `../../../../../../download/en-us/download.md` but become `../../../../../../en-us/download/download.md` after we render it.

I think there is todo task for us, we should make our doc easy to maintain by using path same as relative location. It more easy to write with auto-complete plugin.  All I have to do is type `download` and select the relative location as screenshot

![image](https://user-images.githubusercontent.com/15820530/139374729-cb5133d0-307b-42ce-b0bf-cff5fb2d47a6.png)

