### PR TITLE
Correct dolphinscheduler versions to 2.0.0-alpha

### DIFF
--- a/site_config/site.js
+++ b/site_config/site.js
@@ -21,12 +21,12 @@ export default {
         children: [
           {
             key: 'docs0',
-            text: 'latest(2.0.0)',
+            text: 'latest(2.0.0-alpha)',
             link: '/en-us/docs/latest/user_doc/guide/quick-start.html',
           },
           {
             key: 'docs200',
-            text: '2.0.0',
+            text: '2.0.0-alpha',
             link: '/en-us/docs/2.0.0/user_doc/guide/quick-start.html',
           },
           {
@@ -243,12 +243,12 @@ export default {
         children: [
           {
             key: 'docs0',
-            text: 'latest(2.0.0)',
+            text: 'latest(2.0.0-alpha)',
             link: '/zh-cn/docs/latest/user_doc/guide/quick-start.html',
           },
           {
             key: 'docs200',
-            text: '2.0.0',
+            text: '2.0.0-alpha',
             link: '/zh-cn/docs/2.0.0/user_doc/guide/quick-start.html',
           },
           {


### PR DESCRIPTION
After this patch merge, our website would look like. 
![image](https://user-images.githubusercontent.com/15820530/139395342-dbebf2f5-af6f-441a-898e-c95b8dc65c49.png)
