### PR TITLE
[DOC-7944] [fix]typo guide's parameter

### DIFF
--- a/docs/en-us/2.0.2/user_doc/guide/parameter/context.md
+++ b/docs/en-us/2.0.2/user_doc/guide/parameter/context.md
@@ -8,7 +8,7 @@ The premise of local tasks referencing global parameters is that you have alread
 
 ![parameter-call-global-in-local](/img/global_parameter.png)
 
-As shown in the figure above, `${biz_date}` and `${curdate}` are examples of local parameters referencing global parameters. Observe the last line of the above figure, local_param_bizdate uses \${global_bizdate} to refer to the global parameter. In the shell script, you can use \${local_param_bizdate} to refer to the value of the global variable global_bizdate, or set the value of local_param_bizdate directly through JDBC. In the same way, local_param refers to the global parameters defined in the previous section through ${local_param}. ​Biz_date, biz_curdate, system.datetime are all user-defined parameters, which are assigned via ${global parameters}.
+As shown in the figure above, `${biz_date}` and `${biz_curdate}` are examples of local parameters referencing global parameters. Observe the last line of the above figure, local_param_bizdate uses \${global_bizdate} to refer to the global parameter. In the shell script, you can use \${local_param_bizdate} to refer to the value of the global variable global_bizdate, or set the value of local_param_bizdate directly through JDBC. In the same way, local_param refers to the global parameters defined in the previous section through ${local_param}. ​Biz_date, biz_curdate, system.datetime are all user-defined parameters, which are assigned via ${global parameters}.
 
 ## Pass parameter from upstream task to downstream
 

--- a/docs/en-us/2.0.2/user_doc/guide/parameter/local.md
+++ b/docs/en-us/2.0.2/user_doc/guide/parameter/local.md
@@ -16,4 +16,4 @@ The approach to set local parameters is, double-click on any node while defining
      <img src="/img/global_parameter_en.png" width="80%" />
 </p>
 
-If you want to call the [built-in parameter](built-in.md) in the local parameters, fill in the value corresponding to the built-in parameters in `value`, as in the above figure, `${biz_date}` and `${curdate}`
+If you want to call the [built-in parameter](built-in.md) in the local parameters, fill in the value corresponding to the built-in parameters in `value`, as in the above figure, `${biz_date}` and `${biz_curdate}`

--- a/docs/zh-cn/2.0.2/user_doc/guide/parameter/context.md
+++ b/docs/zh-cn/2.0.2/user_doc/guide/parameter/context.md
@@ -8,7 +8,7 @@ DolphinScheduler 提供参数间相互引用的能力，包括：本地参数引
 
 ![parameter-call-global-in-local](/img/global_parameter.png)
 
-如上图中的`${biz_date}`以及`${curdate}`，就是本地参数引用全局参数的例子。观察上图的最后一行，local_param_bizdate通过\${global_bizdate}来引用全局参数，在shell脚本中可以通过\${local_param_bizdate}来引全局变量 global_bizdate的值，或通过JDBC直接将local_param_bizdate的值set进去。同理，local_param通过${local_param}引用上一节中定义的全局参数。​biz_date、biz_curdate、system.datetime都是用户自定义的参数，通过${全局参数}进行赋值。
+如上图中的`${biz_date}`以及`${biz_curdate}`，就是本地参数引用全局参数的例子。观察上图的最后一行，local_param_bizdate通过\${global_bizdate}来引用全局参数，在shell脚本中可以通过\${local_param_bizdate}来引全局变量 global_bizdate的值，或通过JDBC直接将local_param_bizdate的值set进去。同理，local_param通过${local_param}引用上一节中定义的全局参数。​biz_date、biz_curdate、system.datetime都是用户自定义的参数，通过${全局参数}进行赋值。
 
 ## 上游任务传递给下游任务
 

--- a/docs/zh-cn/2.0.2/user_doc/guide/parameter/local.md
+++ b/docs/zh-cn/2.0.2/user_doc/guide/parameter/local.md
@@ -16,4 +16,4 @@
    <img src="/img/global_parameter.png" width="80%" />
 </p>
 
-如果想要在本地参数中调用系统内置参数，将内置参数对应的值填到`value`中，如上图中的`${biz_date}`以及`${curdate}`
+如果想要在本地参数中调用系统内置参数，将内置参数对应的值填到`value`中，如上图中的`${biz_date}`以及`${biz_curdate}`


### PR DESCRIPTION
update `${curdate}` to `${biz_curdate}` according to the images both in context.md and local.md

this close [7944](https://github.com/apache/dolphinscheduler/issues/7944)