### PR TITLE
[ci] Only run website deploy when push to master branch

### DIFF
--- a/.dlc.json
+++ b/.dlc.json
@@ -4,6 +4,9 @@
       "pattern": "^http://localhost"
     },
     {
+      "pattern": "^https://hive.apache.org"
+    },
+    {
       "pattern": "^http://192"
     }
   ],

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,6 +1,9 @@
 name: Build and Deploy
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 env:
   PYDS_HOME: dolphinscheduler-python/pydolphinscheduler


### PR DESCRIPTION
To avoid trigger website build when push
to other remote branch. Other branch maybe
refactor and will delete some exists content