### PR TITLE
[docker][docs] Removed extra equals after mail user env variable

### DIFF
--- a/docs/en-us/dev/user_doc/guide/installation/docker.md
+++ b/docs/en-us/dev/user_doc/guide/installation/docker.md
@@ -978,7 +978,7 @@ This environment variable sets mail server port for `alert-server`. The default 
 
 This environment variable sets mail sender for `alert-server`. The default value is empty.
 
-**`MAIL_USER=`**
+**`MAIL_USER`**
 
 This environment variable sets mail user for `alert-server`. The default value is empty.
 


### PR DESCRIPTION
Removed extra `=` after `MAIL_USER` env variable to be consistent with other env variables.