### PR TITLE
[fix][scripts]: prepare_docs.sh supports image path conversion.

### DIFF
--- a/blog/en-us/Apache_dolphinScheduler_3.0.0_alpha.md
+++ b/blog/en-us/Apache_dolphinScheduler_3.0.0_alpha.md
@@ -88,7 +88,7 @@ Amazon EMR Task Definition
 
 Amazon Redshift support
 
-* For **Amazon S3**, we have extended the Apache DolphinScheduler's resource center to support not only local resources, HDFS resource storage but also Amazon S3 as a resource centre for storage. Details can be found at: [https://dolphinscheduler.apache.org/zh-cn/docs/latest/user_doc/guide/resource.html](https://dolphinscheduler.apache.org/zh-cn/docs/latest/user_doc/guide/resource.html) in
+* For **Amazon S3**, we have extended the Apache DolphinScheduler's resource center to support not only local resources, HDFS resource storage but also Amazon S3 as a resource centre for storage. Details can be found at: [https://dolphinscheduler.apache.org/zh-cn/docs/3.0.0/user_doc/guide/resource/configuration.html](https://dolphinscheduler.apache.org/zh-cn/docs/3.0.0/user_doc/guide/resource/configuration.html) in
 ```plain
 `resource.storage.type`
 ```
@@ -135,7 +135,7 @@ Data quality verification is now natively supported in 3.0.0-alpha, with support
 
 Task groups are used to control the concurrency of task instances and to define the priority of the group. When creating a new task definition, the user can configure the task group corresponding to the current task and configure the priority of the task to run within the task group. When a task is configured with a task group, the task can be executed only meeting the condition that all upstream tasks run successfully but also the task currently running in the task group is smaller than the size of the resource pool. When it is greater than or equal to the size of the resource pool, the task will wait until the next check. When multiple tasks in a task group are in the pending queue at the same time, the task with the highest priority will be run first.
 
-See the link for details: [https://dolphinscheduler.apache.org/zh-cn/docs/3.0.0/user_doc/guide/resource.html](https://dolphinscheduler.apache.org/zh-cn/docs/3.0.0/user_doc/guide/resource.html)
+See the link for details: [https://dolphinscheduler.apache.org/zh-cn/docs/3.0.0/user_doc/guide/resource/configuration.html](https://dolphinscheduler.apache.org/zh-cn/docs/3.0.0/user_doc/guide/resource/configuration.html)
 
 <div align=center>
 

--- a/blog/zh-cn/Apache_dolphinScheduler_3.0.0_alpha.md
+++ b/blog/zh-cn/Apache_dolphinScheduler_3.0.0_alpha.md
@@ -86,7 +86,7 @@ Amazon EMR 任务定义
 
 Amazon Redshift 支持
 
-对于 Amazon S3，我们扩展了 Apache DolphinScheduler 的资源中心，使其不仅能支持本地资源、HDFS 资源存储，同时支持 Amazon S3 作为资源中心的储存。详情可见：[https://dolphinscheduler.apache.org/zh-cn/docs/latest/user_doc/guide/resource.html](https://dolphinscheduler.apache.org/zh-cn/docs/latest/user_doc/guide/resource.html)中的
+对于 Amazon S3，我们扩展了 Apache DolphinScheduler 的资源中心，使其不仅能支持本地资源、HDFS 资源存储，同时支持 Amazon S3 作为资源中心的储存。详情可见：[https://dolphinscheduler.apache.org/zh-cn/docs/3.0.0/user_doc/guide/resource/configuration.html](https://dolphinscheduler.apache.org/zh-cn/docs/3.0.0/user_doc/guide/resource/configuration.html)中的
 
 ```plain
 `resource.storage.type`

--- a/blog/zh-cn/Apache_dolphinScheduler_3.0.0_alpha.md
+++ b/blog/zh-cn/Apache_dolphinScheduler_3.0.0_alpha.md
@@ -135,7 +135,7 @@ Amazon Redshift 支持
 
 任务组主要用于控制任务实例并发并明确组内优先级。用户在新建任务定义时，可配置当前任务对应的任务组，并配置任务在任务组内运行的优先级。当任务配置了任务组后，任务的执行除了要满足上游任务全部成功外，还需要满足当前任务组正在运行的任务小于资源池的大小。当大于或者等于资源池大小时，任务会进入等待状态等待下一次检查。当任务组中多个任务同时进到待运行队列中时，会先运行优先级高的任务。
 
-详见链接：[https://dolphinscheduler.apache.org/zh-cn/docs/3.0.0/user_doc/guide/resource.html](https://dolphinscheduler.apache.org/zh-cn/docs/3.0.0/user_doc/guide/resource.html)
+详见链接：[https://dolphinscheduler.apache.org/zh-cn/docs/latest/user_doc/guide/resource/configuration.html](https://dolphinscheduler.apache.org/zh-cn/docs/latest/user_doc/guide/resource/configuration.html)
 
 <div align=center>
 

--- a/scripts/prepare_docs.sh
+++ b/scripts/prepare_docs.sh
@@ -93,15 +93,15 @@ function clone_repo() {
 ##############################################################
 #
 # Replace images path in markdown documents, the source path
-# in repo `apache/incubator-seatunnel` is like `images/<name>.png`
-# and we should replace it to `images_en/<name>.png`
+# in repo `apache/dolphinscheduler` is like `../../img/<name>.png`
+# and we should replace it to `/img/<name>.png`
 #
 # Arguments:
 #
 #   replace_dir: The directory to replace the img path
 #
 ##############################################################
-function replace_images_path(){
+function replace_images_path() {
   replace_dir=$1
   for file_path in "${replace_dir}"/*; do
     if test -f "${file_path}"; then

--- a/scripts/prepare_docs.sh
+++ b/scripts/prepare_docs.sh
@@ -106,11 +106,11 @@ function replace_images_path(){
   for file_path in "${replace_dir}"/*; do
     if test -f "${file_path}"; then
       if [ "${file_path##*.}"x = "md"x ] || [ "${file_path##*.}"x = "mdx"x ]; then
-        echo "  ---> Replace images path to /doc/image_en in ${file_path}"
+        echo "  ---> Replace images path to /image in ${file_path}"
         if [[ "$OSTYPE" == "darwin"* ]]; then
-          sed -E -i '' "s/(\.\.\/)*images/\/image_en/g" "${file_path}"
+          sed -E -i '' "s/(\.\.\/)+img/\/img/g" "${file_path}"
         else
-          sed -E -i "s/(\.\.\/)*images/\/image_en/g" "${file_path}"
+          sed -E -i "s/(\.\.\/)+img/\/img/g" "${file_path}"
         fi
       fi
     else
@@ -147,6 +147,9 @@ function prepare_docs() {
 
     echo "  ---> Sync latest document in dev branch."
     rsync_latest_docs
+
+    echo "===>>>: Replace images path in ${PROJECT_SITE_DOC_DIR}"
+    replace_images_path "${PROJECT_SITE_DOC_DIR}"
 
     echo "===>>> End prepare document."
 }


### PR DESCRIPTION
Since viewing md on github requires a relative path, use '../../../../'.

so it will convert img path and make them work bot github markdown and website.

see my code in https://github.com/apache/dolphinscheduler/pull/10127