### PR TITLE
impv: Remove python api in version 203

### DIFF
--- a/docs/2.0.3/configs/docs2-0-3.js
+++ b/docs/2.0.3/configs/docs2-0-3.js
@@ -217,6 +217,10 @@ export default {
             link: '/en-us/docs/2.0.3/user_doc/guide/security.html',
           },
           {
+            title: 'Open API',
+            link: '/en-us/docs/2.0.3/user_doc/guide/open-api.html',
+          },
+          {
             title: 'Flink',
             link: '/en-us/docs/2.0.3/user_doc/guide/flink-call.html',
           },
@@ -267,19 +271,6 @@ export default {
             link: '/en-us/docs/2.0.3/user_doc/guide/observability/skywalking-agent.html',
           },
         ]
-      },
-      {
-        title: 'API',
-        children: [
-          {
-            title: 'Open API',
-            link: '/en-us/docs/2.0.6/user_doc/guide/open-api.html',
-          },
-          {
-            title: 'PyDolphinScheduler',
-            link: '/python/2.0.3/index.html',
-          },
-        ],
       },
       {
         title: 'FAQ',
@@ -520,6 +511,10 @@ export default {
             link: '/zh-cn/docs/2.0.3/user_doc/guide/security.html',
           },
           {
+            title: 'API调用',
+            link: '/zh-cn/docs/2.0.3/user_doc/guide/open-api.html',
+          },
+          {
             title: 'Flink调用',
             link: '/zh-cn/docs/2.0.3/user_doc/guide/flink-call.html',
           },
@@ -570,19 +565,6 @@ export default {
             link: '/zh-cn/docs/2.0.3/user_doc/guide/observability/skywalking-agent.html',
           },
         ]
-      },
-      {
-        title: 'API',
-        children: [
-          {
-            title: 'API调用',
-            link: '/zh-cn/docs/2.0.6/user_doc/guide/open-api.html',
-          },
-          {
-            title: 'PyDolphinScheduler',
-            link: '/python/2.0.3/index.html',
-          },
-        ],
       },
       {
         title: 'FAQ',


### PR DESCRIPTION
Have a dead link in https://dolphinscheduler.apache.org/python/2.0.3/index.html