### PR TITLE
Fixes: Community Icon Hover Effect

### DIFF
--- a/src/views/Home/Community.jsx
+++ b/src/views/Home/Community.jsx
@@ -36,7 +36,8 @@ export const Community = ({ star, fork }) => {
           </div>
           <Space className="home-community-icons" size={20}>
             <Button
-              icon={<GithubOutlined />}
+              className="home-community-buttons"
+              icon={<GithubOutlined/>}
               type="text"
               size="large"
               shape="circle"
@@ -44,6 +45,7 @@ export const Community = ({ star, fork }) => {
               target="_blank"
             />
             <Button
+              className="home-community-buttons"
               icon={<SlackOutlined />}
               type="text"
               size="large"
@@ -52,6 +54,7 @@ export const Community = ({ star, fork }) => {
               target="_blank"
             />
             <Button
+              className="home-community-buttons"
               icon={<TwitterOutlined />}
               type="text"
               size="large"

--- a/src/views/Home/community.scss
+++ b/src/views/Home/community.scss
@@ -1,65 +1,67 @@
 .home-community {
-  padding-top: 100px;
-  &-title {
-    font-weight: 700;
-    color: #031b3e;
-    font-size: 50px;
-    text-align: center;
-    padding-bottom: 60px;
+    padding-top: 100px;
+    &-title {
+        font-weight: 700;
+        color: #031b3e;
+        font-size: 50px;
+        text-align: center;
+        padding-bottom: 60px;
+        @media screen and (max-width: 640px) {
+            font-size: 7vw;
+        }
+    }
+    &-content {
+        display: flex;
+        justify-content: space-between;
+    }
+    &-total {
+        display: flex;
+        align-items: center;
+        text-align: center;
+    }
+    &-item {
+        padding-right: 50px;
+    }
+    &-amount {
+        font-weight: 700;
+        color: var(--primary-color);
+        font-size: 60px;
+        @media screen and (max-width: 640px) {
+            font-size: 10vw;
+        }
+    }
+    &-text {
+        color: #000000;
+        font-size: 20px;
+        margin-top: 8px;
+        @media screen and (max-width: 640px) {
+            font-size: 16px;
+        }
+    }
+    .ant-divider-vertical {
+        height: 80px;
+        border-color: #707070;
+        margin-right: 50px;
+    }
+    &-icons {
+        margin-top: 30px;
+        margin-bottom: 50px;
+    }
+    .anticon {
+        font-size: 30px;
+        &:hover {
+            color: var(--primary-color);
+        }
+    }
+    .ant-image {
+        @media screen and (max-width: 640px) {
+            display: none;
+        }
+    }
+}
 
-    @media screen and (max-width: 640px) {
-      font-size: 7vw;
-    }
-  }
-  &-content {
-    display: flex;
-    justify-content: space-between;
-  }
-
-  &-total {
-    display: flex;
-    align-items: center;
-    text-align: center;
-  }
-  &-item {
-    padding-right: 50px;
-  }
-  &-amount {
-    font-weight: 700;
-    color: var(--primary-color);
-    font-size: 60px;
-
-    @media screen and (max-width: 640px) {
-      font-size: 10vw;
-    }
-  }
-  &-text {
-    color: #000000;
-    font-size: 20px;
-    margin-top: 8px;
-
-    @media screen and (max-width: 640px) {
-      font-size: 16px;
-    }
-  }
-  .ant-divider-vertical {
-    height: 80px;
-    border-color: #707070;
-    margin-right: 50px;
-  }
-  &-icons {
-    margin-top: 30px;
-    margin-bottom: 50px;
-  }
-  .anticon {
-    font-size: 30px;
-    &:hover {
-      color: var(--primary-color);
-    }
-  }
-  .ant-image {
-    @media screen and (max-width: 640px) {
-      display: none;
-    }
-  }
+.home-community-icons .home-community-buttons:hover,
+.home-community-icons .home-community-buttons:active,
+.home-community-icons .home-community-buttons:focus {
+    background-color: transparent !important;
 }

--- a/src/views/Home/community.scss
+++ b/src/views/Home/community.scss
@@ -1,65 +1,68 @@
 .home-community {
     padding-top: 100px;
     &-title {
-        font-weight: 700;
-        color: #031b3e;
-        font-size: 50px;
-        text-align: center;
-        padding-bottom: 60px;
-        @media screen and (max-width: 640px) {
-            font-size: 7vw;
-        }
+      font-weight: 700;
+      color: #031b3e;
+      font-size: 50px;
+      text-align: center;
+      padding-bottom: 60px;
+  
+      @media screen and (max-width: 640px) {
+        font-size: 7vw;
+      }
     }
     &-content {
-        display: flex;
-        justify-content: space-between;
+      display: flex;
+      justify-content: space-between;
     }
+  
     &-total {
-        display: flex;
-        align-items: center;
-        text-align: center;
+      display: flex;
+      align-items: center;
+      text-align: center;
     }
     &-item {
-        padding-right: 50px;
+      padding-right: 50px;
     }
     &-amount {
-        font-weight: 700;
-        color: var(--primary-color);
-        font-size: 60px;
-        @media screen and (max-width: 640px) {
-            font-size: 10vw;
-        }
+      font-weight: 700;
+      color: var(--primary-color);
+      font-size: 60px;
+  
+      @media screen and (max-width: 640px) {
+        font-size: 10vw;
+      }
     }
     &-text {
-        color: #000000;
-        font-size: 20px;
-        margin-top: 8px;
-        @media screen and (max-width: 640px) {
-            font-size: 16px;
-        }
+      color: #000000;
+      font-size: 20px;
+      margin-top: 8px;
+  
+      @media screen and (max-width: 640px) {
+        font-size: 16px;
+      }
     }
     .ant-divider-vertical {
-        height: 80px;
-        border-color: #707070;
-        margin-right: 50px;
+      height: 80px;
+      border-color: #707070;
+      margin-right: 50px;
     }
     &-icons {
-        margin-top: 30px;
-        margin-bottom: 50px;
+      margin-top: 30px;
+      margin-bottom: 50px;
     }
     .anticon {
-        font-size: 30px;
-        &:hover {
-            color: var(--primary-color);
-        }
+      font-size: 30px;
+      &:hover {
+        color: var(--primary-color);
+      }
     }
     .ant-image {
-        @media screen and (max-width: 640px) {
-            display: none;
-        }
+      @media screen and (max-width: 640px) {
+        display: none;
+      }
     }
 }
-
 .home-community-icons .home-community-buttons:hover,
 .home-community-icons .home-community-buttons:active,
 .home-community-icons .home-community-buttons:focus {


### PR DESCRIPTION
**Current Behavior**
When hovering over the community icons, a grey background appears which doesn't perfectly fit the icon, causing an undesirable visual effect.

[current_behavior.webm](https://github.com/apache/dolphinscheduler-website/assets/107138786/e0718121-3ccb-4391-a1e9-784c45bcdb19)


**Proposed Solution:**
To address this issue, we recommend updating the styles for the `.home-community-buttons` class on hover, active, and focus states. This ensures a clean and seamless appearance without any unwanted background effects.

**Behavior after changes:**

[Behavior_after_changes.webm](https://github.com/apache/dolphinscheduler-website/assets/107138786/c2e98e7b-5f4e-4d63-8686-2999c6990972)


