### PR TITLE
Fix duplicating text in URL when navigating to pages in Documentation

### DIFF
--- a/scripts/replace_links.js
+++ b/scripts/replace_links.js
@@ -1,75 +1,26 @@
 const replaceDeadLinks = (content, lang, version) => {
   return content
     .replaceAll(
-      `https://dolphinscheduler.apache.org/${lang}/download/download.html`,
-      `/${lang}/download`
-    )
-    .replaceAll(
-      `pseudo-cluster.md`,
-      `/${lang}/docs/${version}/guide/installation/pseudo-cluster`
-    )
-    .replaceAll(
-      `standalone.md`,
-      `/${lang}/docs/${version}/guide/installation/standalone`
-    )
-    .replaceAll(
       `kubernetes.md`,
       `/${lang}/docs/${version}/guide/installation/kubernetes`
     )
     .replaceAll(
-      `cluster.md`,
-      `/${lang}/docs/${version}/guide/installation/cluster`
-    )
-    .replaceAll(
-      `general-setting.md`,
-      `https://github.com/apache/dolphinscheduler/blob/${version}-release/docs/docs/${
-        lang === "en-us" ? "en" : "zh"
-      }/guide/howto/general-setting.md`
-    )
-    .replaceAll(
-      `../en/guide/alert/email.md`,
-      `/en-us/docs/${version}/guide/alert/email`
+      `guide/alert/email.md`,
+      `/${lang}/docs/${version}/guide/alert/email`
     )
     .replaceAll(
       `../guide/homepage.md`,
       `/${lang}/docs/${version}/guide/homepage`
-    )
-    .replaceAll(
-      `./development-environment-setup.md`,
-      `https://github.com/apache/dolphinscheduler/blob/${version}-release/docs/docs/${
-        lang === "en-us" ? "en" : "zh"
-      }/contribute/development-environment-setup.md`
-    )
-    .replaceAll(
-      `./frontend-development.md`,
-      `https://github.com/apache/dolphinscheduler/blob/${version}-release/docs/docs/${
-        lang === "en-us" ? "en" : "zh"
-      }/contribute/frontend-development.md`
-    )
-    .replaceAll(
-      `../guide/homepage.md`,
-      `/${lang}/docs/${version}/guide/homepage`
-    )
-    .replaceAll(`./security.md`, `/${lang}/docs/${version}/guide/security`)
-    .replaceAll(
-      `../start/quick-start.md`,
-      `/${lang}/docs/${version}/guide/start/quick-start`
     )
     .replaceAll(
       `priority.md`,
       `/${lang}/docs/${version}/guide/parameter/priority`
     )
-    .replaceAll(`global.md`, `/${lang}/docs/${version}/guide/parameter/global`)
     .replaceAll(`local.md`, `/${lang}/docs/${version}/guide/parameter/local`)
-    .replaceAll(`../task/shell.md`, `/${lang}/docs/${version}/guide/task/shell`)
     .replaceAll(`../task/sql.md`, `/${lang}/docs/${version}/guide/task/sql`)
     .replaceAll(
       `../task/stored-procedure.md`,
       `/${lang}/docs/${version}/guide/task/stored-procedure`
-    )
-    .replaceAll(
-      `../task/python.md`,
-      `/${lang}/docs/${version}/guide/task/python`
     )
     .replaceAll(
       `../resource/configuration.md`,
@@ -85,16 +36,8 @@ const replaceDeadLinks = (content, lang, version) => {
       `/${lang}/docs/${version}/guide/project/workflow-definition`
     )
     .replaceAll(
-      `../parameter/global.md`,
-      `/${lang}/docs/${version}/guide/parameter/global`
-    )
-    .replaceAll(
       `./task-instance.md`,
       `/${lang}/docs/${version}/guide/project/task-instance`
-    )
-    .replaceAll(
-      `../installation/standalone.md`,
-      `/${lang}/docs/${version}/guide/installation/standalone`
     )
     .replaceAll(
       `../../architecture/configuration.md`,
@@ -102,9 +45,6 @@ const replaceDeadLinks = (content, lang, version) => {
     )
     .replaceAll(`appendix.md`, `/${lang}/docs/${version}/guide/task/appendix`)
     .replaceAll(`switch.md`, `/${lang}/docs/${version}/guide/task/switch`)
-    .replaceAll(`shell.md`, `/${lang}/docs/${version}/guide/task/shell`)
-    .replaceAll(`./python.md`, `/${lang}/docs/${version}/guide/task/python`)
-    .replaceAll(`../security.md`, `/${lang}/docs/${version}/guide/security`)
     .replaceAll(
       `../resource/file-manage.md`,
       `/${lang}/docs/${version}/guide/resource/file-manage`
@@ -115,30 +55,64 @@ const replaceDeadLinks = (content, lang, version) => {
       `/${lang}/docs/${version}/guide/upgrade/incompatible`
     )
     .replaceAll(
-      `../installation/cluster.md`,
-      `/${lang}/docs/${version}/guide/installation/cluster`
+      /((\.\.\/)*(task\/)|(\.\/)?)python.md/g,
+      `/${lang}/docs/${version}/guide/task/python`
     )
     .replaceAll(
-      `../installation/pseudo-cluster.md`,
+      /((\.\.\/)*(parameter\/)?)global.md/g,
+      `/${lang}/docs/${version}/guide/parameter/global`
+    )
+    .replaceAll(
+      /((\.\.\/)*(installation\/)?)standalone.md/g,
+      `/${lang}/docs/${version}/guide/installation/standalone`
+    )
+    .replaceAll(
+      /((\.\.\/)*(security\/)|(\.\/)?)security.md/g,
+      `/${lang}/docs/${version}/guide/security/security`
+    )
+    .replaceAll(
+      /((\.\.\/)*(task\/)?)shell.md/g,
+      `/${lang}/docs/${version}/guide/task/shell`
+    )
+    .replaceAll(
+      /((\.\.\/)*(installation\/)?)pseudo-cluster.md/g,
       `/${lang}/docs/${version}/guide/installation/pseudo-cluster`
     )
     .replaceAll(
-      `../zh/guide/alert/email.md`,
-      `/zh-cn/docs/${version}/guide/alert/email`
-    )
-    .replaceAll(
-      `installation/cluster.md`,
+      /((\.\.\/)*(installation\/)?)cluster.md/g,
       `/${lang}/docs/${version}/guide/installation/cluster`
     )
     .replaceAll(
-      /((\.\.\/)*(howto\/)?)datasource-setting.md/g,
+      /((\.\.\/)*?)start\/quick-start.md/g,
+      `/${lang}/docs/${version}/guide/start/quick-start`
+    )
+    .replaceAll(
+      /((\.\.\/)*(installation\/)?)datasource-setting.md/g,
+      `/${lang}/docs/${version}/guide/installation/datasource-setting`
+    )
+    .replaceAll(
+      `./development-environment-setup.md`,
+      `/${lang}/docs/${version}/contribute/development-environment-setup`
+    )
+    .replaceAll(
+      `./frontend-development.md`,
+      `/${lang}/docs/${version}/contribute/frontend-development`
+    )
+    .replaceAll(
+      `https://dolphinscheduler.apache.org/${lang}/download/download.html`,
+      `/${lang}/download`
+    )
+    .replaceAll(
+      /datasource-setting.md/g,
       `https://github.com/apache/dolphinscheduler/blob/${version}-release/docs/docs/${
         lang === "en-us" ? "en" : "zh"
       }/guide/howto/datasource-setting.md`
     )
     .replaceAll(
-      `start/quick-start.md`,
-      `/${lang}/docs/${version}/guide/start/quick-start`
+      `general-setting.md`,
+      `https://github.com/apache/dolphinscheduler/blob/${version}-release/docs/docs/${
+        lang === "en-us" ? "en" : "zh"
+      }/guide/howto/general-setting.md`
     );
 };
 


### PR DESCRIPTION
### Issues:
- Navigating from specific pages to another in Documentation, causing duplicate text in the URL, e.g, `https://dolphinscheduler.apache.org/en-us/docs/3.3.0-alpha/guide/installation//en-us/docs/3.3.0-alpha/guide/installation/cluster`
![image](https://github.com/user-attachments/assets/71a80ee0-ec18-46f5-940b-e833a6285bea)

### Causes:
- Having multiple repeated `replaceAll`.
- E.g: Having `cluster.md` replaceAll to `/en-us/docs/3.3.0-alpha/guide/installation/cluster`, then another replaceAll for `installation/cluster.md` to again `/en-us/docs/3.3.0-alpha/guide/installation/cluster`. Causing duplicates in routing URL

### Fixes:
- Using regex to match possible route, it will match `cluster.md`, `installation/cluster.md`, avoiding duplicate replaceAll usage.
