### PR TITLE
fix: choose by your deployment requirement link error

### DIFF
--- a/src/views/Download/index.jsx
+++ b/src/views/Download/index.jsx
@@ -37,7 +37,7 @@ const Download = () => {
               className="download-item-more"
               type="link"
               onClick={() => {
-                navigate(`/${params.locale}/download/deployment`);
+                navigate(`/${params.locale}/download/${versions[0]}`);
               }}
             >
               {t("learn_more")}


### PR DESCRIPTION
<img width="637" alt="Snipaste_2025-04-29_00-23-41" src="https://github.com/user-attachments/assets/32b9374d-2db1-4f54-9b34-f37865ce2104" />
<img width="976" alt="Snipaste_2025-04-29_00-23-12" src="https://github.com/user-attachments/assets/9aa458dc-8092-4a77-8e38-6d67bd0c75b3" />

Fixes an error when clicking the see more link under choose by your deployment requirement.