### PR TITLE
feat(docs): integrate Kapa.ai Ask AI widget into layout

### DIFF
--- a/src/views/Layout/index.jsx
+++ b/src/views/Layout/index.jsx
@@ -1,3 +1,4 @@
+import React, { useEffect } from "react";
 import { ConfigProvider, FloatButton } from "antd";
 import { useParams, Navigate, Outlet } from "react-router-dom";
 import { NavBar, Footer } from "../../components";
@@ -17,7 +18,32 @@ const Content = () => {
 };
 
 const Layout = () => {
+  useEffect(() => {
+    if (document.getElementById("kapa-ai-widget")) {
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.id = "kapa-ai-widget";
+    script.src = "https://widget.kapa.ai/kapa-widget.bundle.js";
+    script.setAttribute("data-website-id", "apache-dolphinscheduler");
+    script.setAttribute("data-project-name", "Apache DolphinScheduler");
+    script.setAttribute("data-project-color", "#0097E0");
+    script.setAttribute("data-button-text", "Ask AI");
+    script.async = true;
+
+    document.body.appendChild(script);
+
+    return () => {
+      const existingScript = document.getElementById("kapa-ai-widget");
+      if (existingScript) {
+        document.body.removeChild(existingScript);
+      }
+    };
+  }, []);
+
   const params = useParams();
+
   if (params.locale && ["en-us", "zh-cn"].includes(params.locale)) {
     const locales = JSON.parse(sessionStorage.getItem("locales")) || {};
 
@@ -43,7 +69,9 @@ const Layout = () => {
           <article className="ds-main" id="ds-scroll-content">
             <Content />
             <FloatButton.BackTop
-              target={() => document.getElementById("ds-scroll-content")}
+              target={() =>
+                document.getElementById("ds-scroll-content")
+              }
             />
             <Footer />
           </article>


### PR DESCRIPTION
Integrate Kapa.ai documentation assistant into the DolphinScheduler website, allowing users to ask AI-powered questions about DolphinScheduler documentation directly from any docs page.

## Changes Made
- Added Kapa.ai widget script to the main layout component (`src/views/Layout/index.jsx`)
- Configured widget with project-specific settings (website-id, project name, color, button text)
- Ensures script is only injected once and properly cleaned up

## Testing
- Widget loads correctly on all documentation pages
- Mobile and desktop responsiveness
- No impact on website performance

## Related Issues
- Closes #17775: Add Kapa.ai docs assistant integration to DolphinScheduler

## Security Considerations
- Kapa.ai script loaded from official CDN
- No sensitive data exposed to third-party service
- Compliance with ASF policies and guidelines