### PR TITLE
[Fix-18324] Fix download link 404 in 3.4.2

### DIFF
--- a/config/download.json
+++ b/config/download.json
@@ -2,14 +2,14 @@
   "3.4.2": {
     "time": "2026-6-3",
     "src": {
-      "src": "https://downloads.apache.org/dolphinscheduler/3.4.1/apache-dolphinscheduler-3.4.2-src.tar.gz",
-      "asc": "https://downloads.apache.org/dolphinscheduler/3.4.1/apache-dolphinscheduler-3.4.2-src.tar.gz.asc",
-      "sha512": "https://downloads.apache.org/dolphinscheduler/3.4.1/apache-dolphinscheduler-3.4.2-src.tar.gz.sha512"
+      "src": "https://downloads.apache.org/dolphinscheduler/3.4.2/apache-dolphinscheduler-3.4.2-src.tar.gz",
+      "asc": "https://downloads.apache.org/dolphinscheduler/3.4.2/apache-dolphinscheduler-3.4.2-src.tar.gz.asc",
+      "sha512": "https://downloads.apache.org/dolphinscheduler/3.4.2/apache-dolphinscheduler-3.4.2-src.tar.gz.sha512"
     },
     "bin": {
-      "src": "https://downloads.apache.org/dolphinscheduler/3.4.1/apache-dolphinscheduler-3.4.2-bin.tar.gz",
-      "asc": "https://downloads.apache.org/dolphinscheduler/3.4.1/apache-dolphinscheduler-3.4.2-bin.tar.gz.asc",
-      "sha512": "https://downloads.apache.org/dolphinscheduler/3.4.1/apache-dolphinscheduler-3.4.2-bin.tar.gz.sha512"
+      "src": "https://downloads.apache.org/dolphinscheduler/3.4.2/apache-dolphinscheduler-3.4.2-bin.tar.gz",
+      "asc": "https://downloads.apache.org/dolphinscheduler/3.4.2/apache-dolphinscheduler-3.4.2-bin.tar.gz.asc",
+      "sha512": "https://downloads.apache.org/dolphinscheduler/3.4.2/apache-dolphinscheduler-3.4.2-bin.tar.gz.sha512"
     }
   },
   "3.4.1": {


### PR DESCRIPTION
fix https://github.com/apache/dolphinscheduler/issues/18324